### PR TITLE
reversed sorting since winston changed log level priorities to follow RFC5424

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports = function(loggers) {
 	Object.keys(loggers).forEach(function(type) {
 		if(!loggers[type]) return;
 
-		// set level to first enabled logger
-		level = level === null ? type : level;
+		// set level to last enabled logger (last one wins)
+		level = type;
 		levels[type] = Object.keys(levels).length;
 	});
 

--- a/index.js
+++ b/index.js
@@ -8,19 +8,19 @@ module.exports = function(loggers) {
 	var level = null,
 		levels = {};
 
-	// put disabled loggers at the top
-	Object.keys(loggers).forEach(function(type) {
-		if(loggers[type]) return;
-
-		levels[type] = Object.keys(levels).length;
-	});
-
-	// append enabled loggers
+	// put enabled loggers at the top
 	Object.keys(loggers).forEach(function(type) {
 		if(!loggers[type]) return;
 
 		// set level to first enabled logger
 		level = level === null ? type : level;
+		levels[type] = Object.keys(levels).length;
+	});
+
+	// append disabled loggers
+	Object.keys(loggers).forEach(function(type) {
+		if(loggers[type]) return;
+
 		levels[type] = Object.keys(levels).length;
 	});
 

--- a/test/leveler.test.js
+++ b/test/leveler.test.js
@@ -25,7 +25,7 @@ describe('Winston No Levels Logger', function() {
         assert.isObject(config.levels);
         assert.isString(config.level);
         assert.equal(config.level, 'warn');
-        assert.deepEqual(config.levels, { info: 0, warn: 1, error: 2});
+        assert.deepEqual(config.levels, { warn: 0, error: 1, info: 2 });
     });
 
     it('should work with three loggers, all enabled', function() {

--- a/test/leveler.test.js
+++ b/test/leveler.test.js
@@ -17,30 +17,30 @@ describe('Winston No Levels Logger', function() {
 
     it('should work with two loggers, one that is disabled', function() {
         var config = leveler({
-            warn: true,
+            error: true,
             info: false,
-            error: true
+            warn: true
         });
 
         assert.isObject(config.levels);
         assert.isString(config.level);
         assert.equal(config.level, 'warn');
-        assert.deepEqual(config.levels, { warn: 0, error: 1, info: 2 });
+        assert.deepEqual(config.levels, { error: 0, warn: 1, info: 2 });
     });
 
-    it('should work with three loggers, all enabled', function() {
+    it('should work with all five loggers, all enabled', function() {
         var config = leveler({
+            error: true,
             warn: true,
             info: true,
-            error: true,
             api: true,
             cache: true
         });
 
         assert.isObject(config.levels);
         assert.isString(config.level);
-        assert.equal(config.level, 'warn');
-        assert.deepEqual(config.levels, { warn: 0, info: 1, error: 2, api: 3, cache: 4});
+        assert.equal(config.level, 'cache');
+        assert.deepEqual(config.levels, { error: 0, warn: 1, info: 2,  api: 3, cache: 4});
     });
 
 });


### PR DESCRIPTION
Winston must have fixed the way they did logging levels a while back to: "as specified exactly in RFC5424 the syslog levels are prioritized from 0 to 7 (highest to lowest)" (https://github.com/winstonjs/winston#logging-levels)
